### PR TITLE
add path to the list of whitelisted-envvars

### DIFF
--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -36,6 +36,7 @@ def dump_scriptvars():
         "TC_WORKER_TYPE",
         "DEVICE_IP",
         "USER",
+        "PATH",
     )
     variables = dict( (k, get_envvar(k)) for k in names )
 


### PR DESCRIPTION
Not having a path set has been causing issues for Glandium (see https://bugzilla.mozilla.org/show_bug.cgi?id=1525373). This change results in a PATH env var being set when g-w is called.

images built:
`04-23 12:19:44.068 Successfully tagged mozilla-image:20190423T121205`

testing with: 
https://phabricator.services.mozilla.com/D28553 and `./mach try fuzzy -q "'android-hw mochi g5" -q "'android-hw tp6m g5"  `

https://treeherder.mozilla.org/#/jobs?repo=try&revision=064368e3d005a38d28a0e3ebc9c510c9629823b2
