### PR TITLE
use mozdevice 3.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN cd /tmp && \
     tar xzf /builds/worker/Downloads/android-sdk_r24.3.4-linux.tgz --directory=/builds/worker || true && \
     unzip -qq -n /builds/worker/Downloads/sdk-tools-linux-4333796.zip -d /builds/worker/android-sdk-linux/ || true && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
-    pip install mozdevice==3.0.1 && \
+    pip install mozdevice==3.0.3 && \
     pip install google-cloud-logging && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -23,20 +23,20 @@ def dump_scriptvars():
 
     """
     names = (
-        "TESTDROID_PROJECT_ID",
-        "TESTDROID_BUILD_ID",
-        "TESTDROID_RUN_ID",
-        "HOME",
-        "HOSTNAME",
-        "HOST_IP",
-        "DEVICE_NAME",
         "ANDROID_DEVICE",
+        "DEVICE_IP",
+        "DEVICE_NAME",
         "DEVICE_SERIAL",
+        "HOME",
+        "HOST_IP",
+        "HOSTNAME",
+        "PATH",
         "TC_WORKER_GROUP",
         "TC_WORKER_TYPE",
-        "DEVICE_IP",
+        "TESTDROID_BUILD_ID",
+        "TESTDROID_PROJECT_ID",
+        "TESTDROID_RUN_ID",
         "USER",
-        "PATH",
     )
     variables = dict( (k, get_envvar(k)) for k in names )
 

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -27,6 +27,7 @@ def dump_scriptvars():
         "DEVICE_IP",
         "DEVICE_NAME",
         "DEVICE_SERIAL",
+        "DOCKER_IMAGE_VERSION",
         "HOME",
         "HOST_IP",
         "HOSTNAME",


### PR DESCRIPTION
Also:
  - whitelist DOCKER_IMAGE_VERSION (would be nice to surface in tc logs)

built as: `Successfully tagged mozilla-image:20190731T113428`