### PR TITLE
added python 3.6 specific stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,17 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y software-properties-common python-software-properties
 RUN add-apt-repository ppa:openjdk-r/ppa
 
+# upgrading to Python 3.6
+RUN apt-get install curl
+RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update
+RUN apt-get install -y python3.6
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
+
+# adding a couple of packages for the conditioned profiles
+RUN pip3.6 install arsenic==19.1
+RUN pip3.6 install requests==2.22.0
+
 # libcurl3 required for minidump_stackwalk from releng tooltool
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,8 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:openjdk-r/ppa
-
-# upgrading to Python 3.6
-RUN apt-get install curl
 RUN add-apt-repository ppa:jonathonf/python-3.6
-RUN apt-get update
-RUN apt-get install -y python3.6
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
-
-# adding a couple of packages for the conditioned profiles
-RUN pip3.6 install arsenic==19.1
-RUN pip3.6 install requests==2.22.0
+RUN add-apt-repository ppa:openjdk-r/ppa
 
 # libcurl3 required for minidump_stackwalk from releng tooltool
 
@@ -43,6 +33,7 @@ RUN apt-get update && \
     wget \
     xvfb \
     zip && \
+    python3.6 && \
     apt-get clean all -y
 
 RUN mkdir /builds && \
@@ -124,6 +115,9 @@ RUN cd /tmp && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
     pip install mozdevice==3.0.3 && \
     pip install google-cloud-logging && \
+    curl https://bootstrap.pypa.io/get-pip.py | python3.6 && \
+    pip3.6 install arsenic==19.1 && \
+    pip3.6 install requests==2.22.0 && \
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /builds/worker/Downloads/* && \


### PR DESCRIPTION
This patche would allow me to run the conditioned profile task on android devices. see https://bugzilla.mozilla.org/show_bug.cgi?id=1562870

I am using a modern Python version along with a couple of python packages, on requires 3.6

I don't think this change will affect the current docker image in any particular way, besides the fact that it will have 3.6 installed.
