### PR TITLE
compile and install python 2 and 3 via pyenv

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,6 +15,13 @@ export PATH=${PATH}:/usr/local/bin:/builds/worker/android-sdk-linux/platform-too
 # Work around broken libcurl3 minidump_stackwalk requirement.
 export LD_LIBRARY_PATH=/builds/worker/LD_LIBRARY
 
+# setup pyenv
+export PYENV_ROOT=$HOME/.pyenv
+export PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+if command -v pyenv 1>/dev/null 2>&1; then
+  eval "$(pyenv init -)"
+fi
+
 # Set umask 0 so that a setuid adb will create world readable/writeable
 # files while the process is running as the worker user.
 umask 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,21 +81,21 @@ RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
     pyenv global ${PY2_VERSION} ${PY3_VERSION} && \
     pyenv rehash
 
+# download things
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
-# COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
-
 ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
-# COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
-
 ADD https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
-# COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
-
 ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
-# COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
-
 ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+
+# for testing builds (these lines mirror above), copy above artifacts from the downloads dir
+# COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
+# COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+# COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
+# COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
 # COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
 
+# copy stackdriver credentials over
 COPY stackdriver_credentials.json /etc/google/stackdriver_credentials.json
 
 COPY .bashrc /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,19 @@ RUN apt-get update && \
     curl \
     dnsutils \
     ffmpeg \
+    git \
     lib32stdc++6 \
     lib32z1 \
     libavcodec-dev \
     libavformat-dev \
     libcurl3 \
+    libffi-dev \
     libgconf-2-4 \
     libgtk-3-0 \
     libopencv-dev \
     libpython-dev \
+    libreadline-dev \
+    libssl-dev \
     libswscale-dev \
     locales \
     net-tools \
@@ -26,14 +30,13 @@ RUN apt-get update && \
     openjdk-8-jdk-headless \
     python \
     python-pip \
-    python3 \
-    python3-pip \
     sudo \
     tzdata \
     unzip \
     wget \
     xvfb \
-    zip && \
+    zip \
+    zlib1g-dev && \
     apt-get clean all -y
 
 RUN mkdir /builds && \
@@ -62,6 +65,14 @@ ENV    HOME=/builds/worker \
        LANG=en_US.UTF-8 \
        LC_ALL=en_US.UTF-8 \
        PATH=$PATH:/builds/worker/bin
+
+# install pyenv and python 3
+ENV     PYENV_ROOT=$HOME/.pyenv \
+        PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+RUN git clone git://github.com/yyuu/pyenv.git .pyenv && \
+        pyenv install 3.7.3 && \
+        pyenv global system 3.7.3 && \
+        pyenv rehash
 
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 #COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && \
     openjdk-8-jdk-headless \
     python \
     python-pip \
+    python3 \
+    python3-pip \
     sudo \
     tzdata \
     unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,9 @@ RUN cd /tmp && \
     tar xzf /builds/worker/Downloads/android-sdk_r24.3.4-linux.tgz --directory=/builds/worker || true && \
     unzip -qq -n /builds/worker/Downloads/sdk-tools-linux-4333796.zip -d /builds/worker/android-sdk-linux/ || true && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
+    pip install pip -U && \
+    pip3 install pip -U && \
+    pip install setuptools -U && \
     pip install mozdevice==3.0.5 && \
     pip install google-cloud-logging && \
     rm -rf /tmp/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update && \
     openjdk-8-jdk-headless \
     python \
     python-pip \
+    python3 \
+    python3-pip \
     sudo \
     tzdata \
     unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && \
     dnsutils \
     ffmpeg \
     git \
-    lbzip2 \
     lib32stdc++6 \
     lib32z1 \
     libavcodec-dev \
     libavformat-dev \
+    libbz2-dev \
     libcurl3 \
     libffi-dev \
     libgconf-2-4 \
@@ -23,7 +23,7 @@ RUN apt-get update && \
     libopencv-dev \
     libpython-dev \
     libreadline-dev \
-    libsqlite3-0 \
+    libsqlite3-dev \
     libssl-dev \
     libswscale-dev \
     locales \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     dnsutils \
     ffmpeg \
     git \
+    lbzip2 \
     lib32stdc++6 \
     lib32z1 \
     libavcodec-dev \
@@ -22,6 +23,7 @@ RUN apt-get update && \
     libopencv-dev \
     libpython-dev \
     libreadline-dev \
+    libsqlite3-0 \
     libssl-dev \
     libswscale-dev \
     locales \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,20 +81,20 @@ RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
     pyenv global ${PY2_VERSION} ${PY3_VERSION} && \
     pyenv rehash
 
-# ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
-COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
+ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
+# COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 
-# ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
-COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+# COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
 
-# ADD https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
-COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
+ADD https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
+# COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
 
-# ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
-COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
+ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
+# COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
 
-# ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
-COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+# COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
 
 COPY stackdriver_credentials.json /etc/google/stackdriver_credentials.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,15 @@ ENV    HOME=/builds/worker \
        PATH=$PATH:/builds/worker/bin
 
 # install pyenv and python 3
-ENV     PYENV_ROOT=$HOME/.pyenv \
-        PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-RUN git clone git://github.com/yyuu/pyenv.git .pyenv && \
-        pyenv install 3.7.3 && \
-        pyenv global system 3.7.3 && \
-        pyenv rehash
+ENV PYENV_ROOT=$HOME/.pyenv
+ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+ENV PY3_VERSION=3.7.4
+ENV PY2_VERSION=2.7.9
+RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
+    pyenv install ${PY3_VERSION} && \
+    pyenv install ${PY2_VERSION} && \
+    pyenv global ${PY3_VERSION} ${PY2_VERSION} && \
+    pyenv rehash
 
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 #COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,27 +70,27 @@ ENV    HOME=/builds/worker \
 ENV PYENV_ROOT=$HOME/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 ENV PY3_VERSION=3.7.4
-ENV PY2_VERSION=2.7.9
+ENV PY2_VERSION=2.7.16
 RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
     pyenv install ${PY3_VERSION} && \
     pyenv install ${PY2_VERSION} && \
     pyenv global ${PY2_VERSION} ${PY3_VERSION} && \
     pyenv rehash
 
-ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
-#COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
+# ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
+COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 
-ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
-#COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+# ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
 
-ADD https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
-#COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
+# ADD https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
+COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
 
-ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
-#COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
+# ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
+COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
 
-ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
-#COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+# ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
 
 COPY stackdriver_credentials.json /etc/google/stackdriver_credentials.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV PY2_VERSION=2.7.9
 RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
     pyenv install ${PY3_VERSION} && \
     pyenv install ${PY2_VERSION} && \
-    pyenv global ${PY3_VERSION} ${PY2_VERSION} && \
+    pyenv global ${PY2_VERSION} ${PY3_VERSION} && \
     pyenv rehash
 
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads


### PR DESCRIPTION
The image already has python3 installed, but it's 3.5. 16.04 actually requires python 3 (https://packages.ubuntu.com/xenial/python3-minimal).

Moving to 18.04 and using the system python packages has proven problematic. See https://bugzilla.mozilla.org/show_bug.cgi?id=1503785

pyenv can use multiple pythons at the same time (https://github.com/pyenv/pyenv/#choosing-the-python-version), but I can't get it to use system python 2 and pyenv's python 3. Because of this I install python 2 also.
- `pyenv global system 3.7.4` ends up using both system pythons vs system-py2 and 3.7.4
- `pyenv global 3.7.4 system` ends up using 3.7.4 for python and python3

---

with this change:
```
root@1490898ef6fe:~# python --version
Python 2.7.16
root@1490898ef6fe:~# pip --version
pypip 19.2.2 from /builds/worker/.pyenv/versions/2.7.16/lib/python2.7/site-packages/pip (python 2.7)
root@1490898ef6fe:~# python3 --version
Python 3.7.4
root@1490898ef6fe:~# pip3 --version
pip 19.2.2 from /builds/worker/.pyenv/versions/3.7.4/lib/python3.7/site-packages/pip (python 3.7)
root@1490898ef6fe:~# 
```

current prod bitbar-docker image:

```
root@1490898ef6fe:~# python --version
Python 2.7.12
root@1490898ef6fe:~# pip --version
pip 8.1.1 from /usr/lib/python2.7/dist-packages (python 2.7)
root@1490898ef6fe:~# python3 --version
Python 3.5.2
root@1490898ef6fe:~# pip3 --version
pyenv: pip3: command not found
```