### PR TITLE
reduce disk requirements and show df output

### DIFF
--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -8,7 +8,7 @@
     "numberOfTasksToRun":         1,
     "provisionerId":              "proj-autophone",
     "publicIP":                   "127.0.0.1",
-    "requiredDiskSpaceMegabytes": 5000,
+    "requiredDiskSpaceMegabytes": 6500,
     "rootURL":                    "https://taskcluster.net",
     "workerGroup":                "${TC_WORKER_GROUP}",
     "workerId":                   "${DEVICE_NAME}",

--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -8,7 +8,7 @@
     "numberOfTasksToRun":         1,
     "provisionerId":              "proj-autophone",
     "publicIP":                   "127.0.0.1",
-    "requiredDiskSpaceMegabytes": 7000,
+    "requiredDiskSpaceMegabytes": 5000,
     "rootURL":                    "https://taskcluster.net",
     "workerGroup":                "${TC_WORKER_GROUP}",
     "workerId":                   "${DEVICE_NAME}",

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -33,6 +33,14 @@ def fatal(message, exception=None, retry=True):
         print("{}: {}".format(exception.__class__.__name__, exception))
     sys.exit(exit_code)
 
+def show_df():
+    try:
+        print('\df -h\n%s\n\n' % subprocess.check_output(
+            ['df', '-h'],
+            stderr=subprocess.STDOUT))
+    except subprocess.CalledProcessError as e:
+        print('{} attempting df'.format(e))
+
 def get_device_type(device):
     device_type = device.shell_output("getprop ro.product.model", timeout=ADB_COMMAND_TIMEOUT)
     if device_type == "Pixel 2":
@@ -131,6 +139,8 @@ def main():
         env['HOME'] = '/builds/worker'
         print('setting HOME to {}'.format(env['HOME']))
 
+    show_df()
+
     # If we are running normal tests we will be connected via usb and
     # there should be only one device connected.  If we are running
     # power tests, the framework will have already called adb tcpip
@@ -215,6 +225,8 @@ def main():
             stderr=subprocess.STDOUT))
     except subprocess.CalledProcessError as e:
         print('{} attempting netstat'.format(e))
+
+    show_df()
 
     print('script.py exitcode {}'.format(rc))
     return rc


### PR DESCRIPTION
- require 6.5 GB free disk space vs 7 GB
- log `df` output to TC at start and end of run