### PR TITLE
don't compile py2 or py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,17 +70,6 @@ ENV    HOME=/builds/worker \
        LC_ALL=en_US.UTF-8 \
        PATH=$PATH:/builds/worker/bin
 
-# install pyenv and python 3
-ENV PYENV_ROOT=$HOME/.pyenv
-ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-ENV PY3_VERSION=3.7.4
-ENV PY2_VERSION=2.7.16
-RUN git clone --branch v1.2.13 git://github.com/pyenv/pyenv.git .pyenv && \
-    pyenv install ${PY3_VERSION} && \
-    pyenv install ${PY2_VERSION} && \
-    pyenv global ${PY2_VERSION} ${PY3_VERSION} && \
-    pyenv rehash
-
 # download things
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,8 +120,6 @@ RUN cd /tmp && \
     tar xzf /builds/worker/Downloads/android-sdk_r24.3.4-linux.tgz --directory=/builds/worker || true && \
     unzip -qq -n /builds/worker/Downloads/sdk-tools-linux-4333796.zip -d /builds/worker/android-sdk-linux/ || true && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
-    pip install pip -U && \
-    pip3 install pip -U && \
     pip install setuptools -U && \
     pip install mozdevice==3.0.5 && \
     pip install google-cloud-logging && \


### PR DESCRIPTION
The compiled python2 seems to have serious performance issues. Instead of trying to optimize the build, go back to ubuntu's provided python2.

pyenv can't compile py3 and use system py2 at the same time, so don't compile it either.

python versions with this change:
```
Python 2.7.12
Python 3.5.2
```