### PR TITLE
run_gw.py: remove g-w's resolved task counter file

### DIFF
--- a/scripts/run_gw.py
+++ b/scripts/run_gw.py
@@ -52,6 +52,14 @@ while True:
     superseded = False
     rc = None
 
+    # see https://bugzilla.mozilla.org/show_bug.cgi?id=1375514
+    # prevents g-w from never reaching termination condition when we do our supersede reruns and device issues occur
+    # https://github.com/taskcluster/generic-worker/blob/d3dda694d0031e8f1cd085f06c3b0f810321dac2/main.go#L485
+    gw_resolved_count_file = "tasks-resolved-count.txt"
+    if os.path.exists(gw_resolved_count_file):
+        print("%s/INFO: removed gw_resolved_count_file at '%s'" % gw_resolved_count_file)
+        os.remove(gw_resolved_count_file)
+
     print("%s/INFO: command to run is: '%s'" % (script_name, " ".join(cmd_arr)))
     # run command
     proc = subprocess.Popen(cmd_arr,

--- a/scripts/run_gw.py
+++ b/scripts/run_gw.py
@@ -57,7 +57,7 @@ while True:
     # https://github.com/taskcluster/generic-worker/blob/d3dda694d0031e8f1cd085f06c3b0f810321dac2/main.go#L485
     gw_resolved_count_file = "tasks-resolved-count.txt"
     if os.path.exists(gw_resolved_count_file):
-        print("%s/INFO: removed gw_resolved_count_file at '%s'" % gw_resolved_count_file)
+        print("%s/INFO: removed gw_resolved_count_file at '%s'" % (script_name, gw_resolved_count_file))
         os.remove(gw_resolved_count_file)
 
     print("%s/INFO: command to run is: '%s'" % (script_name, " ".join(cmd_arr)))


### PR DESCRIPTION
Our superseded task code ends up causing g-w to never terminate in certain situations.

Delete g-w's file used for tracking completed tasks as a fix for now. Mentioned originally in https://bugzilla.mozilla.org/show_bug.cgi?id=1375514.

---

from https://github.com/taskcluster/generic-worker/blob/d3dda694d0031e8f1cd085f06c3b0f810321dac2/main.go#L485

```
			remainingTasks := int(config.NumberOfTasksToRun - tasksResolved)
			remainingTaskCountText := ""
			if remainingTasks > 0 {
				remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
			}
			log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
			if remainingTasks == 0 {
```

Bitbar's g-w config sets numberOfTasksToRun to 1. If tasksResolved is > 1, g-w will run forever. The final comparison in the snippet above should be changed to `if remainingTasks <= 0 {`.