### PR TITLE
g-w config: use https://firefox-ci-tc.services.mozilla.com as rootUrl

### DIFF
--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -9,7 +9,7 @@
     "provisionerId":              "proj-autophone",
     "publicIP":                   "127.0.0.1",
     "requiredDiskSpaceMegabytes": 6500,
-    "rootURL":                    "https://taskcluster.net",
+    "rootURL":                    "https://firefox-ci-tc.services.mozilla.com",
     "workerGroup":                "${TC_WORKER_GROUP}",
     "workerId":                   "${DEVICE_NAME}",
     "workerType":                 "${TC_WORKER_TYPE}",


### PR DESCRIPTION
see https://bugzilla.mozilla.org/show_bug.cgi?id=1592377 for more details

Will land Nov 9 at the start of the migration.

Images built from this PR:
- 586c135: `10-29 14:10:10.034 Successfully tagged mozilla-image:20191029T170431` - https://mozilla.testdroid.com/#testing/device-session/1006159/1302258/33128227