### PR TITLE
add zstd binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     wget \
     xvfb \
     zip \
-    zlib1g-dev && \
+    zlib1g-dev \
     zstd && \
     apt-get clean all -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
     xvfb \
     zip \
     zlib1g-dev && \
+    zstd && \
     apt-get clean all -y
 
 RUN mkdir /builds && \


### PR DESCRIPTION
We previously installed the python libraries in python2 and python3, but we're missing the binary.

Waiting until the TCW migration is done and https://github.com/bclary/mozilla-bitbar-docker/pull/29 is merged to merge this PR.