### PR TITLE
script.py: ensure all output is written

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,11 +120,16 @@ RUN cd /tmp && \
     tar xzf /builds/worker/Downloads/android-sdk_r24.3.4-linux.tgz --directory=/builds/worker || true && \
     unzip -qq -n /builds/worker/Downloads/sdk-tools-linux-4333796.zip -d /builds/worker/android-sdk-linux/ || true && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
+    # install python pips
     pip install setuptools -U && \
-    pip install mozdevice==3.0.5 && \
+    pip3 install setuptools -U && \
     pip install google-cloud-logging && \
+    pip3 install google-cloud-logging && \
     pip install zstandard==0.11.1 && \
     pip3 install zstandard==0.11.1 && \
+    pip install mozdevice==3.0.5 && \
+    pip3 install mozdevice==3.0.5 && \
+    # cleanup
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /builds/worker/Downloads/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     curl \
-    vim \
     dnsutils \
     ffmpeg \
     gettext-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN cd /tmp && \
     # upgrade the builtin setuptools
     pip install setuptools -U && \
     pip3 install setuptools -U && \
-    # pips used by pips
+    # pips used by scripts in this docker image
     pip install google-cloud-logging && \
     pip3 install google-cloud-logging && \
     pip install mozdevice==3.0.5 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,8 @@ RUN cd /tmp && \
     # pips used by scripts in this docker image
     pip install google-cloud-logging && \
     pip3 install google-cloud-logging && \
-    pip install mozdevice==3.0.5 && \
-    pip3 install mozdevice==3.0.5 && \
+    pip install mozdevice==3.0.6 && \
+    pip3 install mozdevice==3.0.6 && \
     # pips used by jobs
     pip install zstandard==0.11.1 && \
     pip3 install zstandard==0.11.1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,15 +120,17 @@ RUN cd /tmp && \
     tar xzf /builds/worker/Downloads/android-sdk_r24.3.4-linux.tgz --directory=/builds/worker || true && \
     unzip -qq -n /builds/worker/Downloads/sdk-tools-linux-4333796.zip -d /builds/worker/android-sdk-linux/ || true && \
     /builds/worker/android-sdk-linux/tools/bin/sdkmanager platform-tools "build-tools;28.0.3" && \
-    # install python pips
+    # upgrade the builtin setuptools
     pip install setuptools -U && \
     pip3 install setuptools -U && \
+    # pips used by pips
     pip install google-cloud-logging && \
     pip3 install google-cloud-logging && \
-    pip install zstandard==0.11.1 && \
-    pip3 install zstandard==0.11.1 && \
     pip install mozdevice==3.0.5 && \
     pip3 install mozdevice==3.0.5 && \
+    # pips used by jobs
+    pip install zstandard==0.11.1 && \
+    pip3 install zstandard==0.11.1 && \
     # cleanup
     rm -rf /tmp/* && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04@sha256:017eef0b616011647b269b5c65826e2e2ebddbe5d1f8c1e56b3599fb14fabec8
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
     curl \
+    vim \
     dnsutils \
     ffmpeg \
     gettext-base \

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -47,6 +47,8 @@ def get_device_type(device):
         pass
     elif device_type == "Moto G (5)":
         pass
+    elif device_type == "Android SDK built for x86":
+        pass
     else:
         fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     return device_type
@@ -82,6 +84,8 @@ def enable_charging(device, device_type):
                 device.shell_bool(
                     "echo %s > %s" % (1, g5_path), root=True, timeout=ADB_COMMAND_TIMEOUT
                 )
+        elif device_type == "Android SDK built for x86":
+            pass
         else:
             fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     except ADBError as e:

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -204,14 +204,18 @@ def main():
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
-    while rc == None:
-        written = 0
-        line = proc.stdout.readline()
-        line_bytelen = len(line)
-        while written < line_bytelen:
-            written += sys.stdout.write(str(line))
+    read = 0
+    written = 0
+    while True:
+        output = proc.stdout.readline()
+        line_len = len(output)
         rc = proc.poll()
-    print("script.py: command finished")
+        if line_len == 0 and written == read and rc is not None:
+            break
+        read += len(output)
+        if output:
+            written += sys.stdout.write(str(output.decode()))
+    print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -35,7 +35,7 @@ def fatal(message, exception=None, retry=True):
 
 def show_df():
     try:
-        print('\df -h\n%s\n\n' % subprocess.check_output(
+        print('\ndf -h\n%s\n\n' % subprocess.check_output(
             ['df', '-h'],
             stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
@@ -55,7 +55,7 @@ def get_device_type(device):
 
 
 def enable_charging(device, device_type):
-    print("script.py: enabling charging for %s (%s)..." % (device, device_type))
+    print("script.py: enabling charging for device '%s' ('%s')..." % (device_type, device.get_info('id')['id']))
     p2_path = "/sys/class/power_supply/battery/input_suspend"
     g5_path = "/sys/class/power_supply/battery/charging_enabled"
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -204,8 +204,11 @@ def main():
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     while rc == None:
+        written = 0
         line = proc.stdout.readline()
-        sys.stdout.write(line)
+        line_bytelen = len(bytes(line))
+        while written < line_bytelen:
+            written += (sys.stdout.write(line) or 0)
         rc = proc.poll()
 
     # enable charging on device if it is disabled

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -211,10 +211,10 @@ def main():
         line_len = len(line)
         read += line_len
         rc = proc.poll()
+        if line:
+            written += sys.stdout.write(str(line.decode()))        
         if line_len == 0 and written == read and rc is not None:
             break
-        if line:
-            written += sys.stdout.write(str(line.decode()))
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))
 
     # enable charging on device if it is disabled

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -197,7 +197,7 @@ def main():
     print('environment = {}'.format(json.dumps(env, indent=4)))
 
     # run the payload's command
-    print(' '.join(extra_args))
+    print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None
     read = 0
     written = 0
@@ -212,7 +212,7 @@ def main():
         read += line_len
         rc = proc.poll()
         if line:
-            written += sys.stdout.write(str(line.decode()))        
+            written += sys.stdout.write(str(line.decode()))
         if line_len == 0 and written == read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -211,7 +211,7 @@ def main():
         while written < line_bytelen:
             written += sys.stdout.write(str(line))
         rc = proc.poll()
-    print("script.py: payload command finished")
+    print("script.py: command finished")
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -199,6 +199,7 @@ def main():
     print(' '.join(extra_args))
     rc = None
     proc = subprocess.Popen(extra_args,
+                            bufsize=0,
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -209,10 +209,10 @@ def main():
     while True:
         line = proc.stdout.readline()
         line_len = len(line)
+        read += line_len
         rc = proc.poll()
         if line_len == 0 and written == read and rc is not None:
             break
-        read += line_len
         if line:
             written += sys.stdout.write(str(line.decode()))
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -207,9 +207,9 @@ def main():
     while rc == None:
         written = 0
         line = proc.stdout.readline()
-        line_bytelen = len(bytes(line))
+        line_bytelen = len(line)
         while written < line_bytelen:
-            written += (sys.stdout.write(line) or 0)
+            written += sys.stdout.write(str(line))
         rc = proc.poll()
     print("script.py payload command finished")
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -217,7 +217,6 @@ def main():
         rc = proc.poll()
         if line:
             bytes_written += sys.stdout.write(str(line.decode()))
-        # print("ll: %s, bw: %s, br: %s, rc: %s" % (line_len, bytes_written, bytes_read, rc))
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -207,8 +207,8 @@ def main():
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     while True:
-        output = proc.stdout.readline()
-        line_len = len(output)
+        line = proc.stdout.readline()
+        line_len = len(line)
         rc = proc.poll()
         if line_len == 0 and written == read and rc is not None:
             break

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -212,9 +212,9 @@ def main():
         rc = proc.poll()
         if line_len == 0 and written == read and rc is not None:
             break
-        read += len(output)
-        if output:
-            written += sys.stdout.write(str(output.decode()))
+        read += line_len
+        if line:
+            written += sys.stdout.write(str(line.decode()))
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))
 
     # enable charging on device if it is disabled

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -199,8 +199,8 @@ def main():
     # run the payload's command
     print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None
-    read = 0
-    written = 0
+    bytes_read = 0
+    bytes_written = 0
     proc = subprocess.Popen(extra_args,
                             bufsize=0,
                             env=env,
@@ -209,13 +209,13 @@ def main():
     while True:
         line = proc.stdout.readline()
         line_len = len(line)
-        read += line_len
+        bytes_read += line_len
         rc = proc.poll()
         if line:
-            written += sys.stdout.write(str(line.decode()))
-        if line_len == 0 and written == read and rc is not None:
+            bytes_written += sys.stdout.write(str(line.decode()))
+        if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
-    print("script.py: command finished (bytes read: %s, bytes written: %s)" % (read, written))
+    print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -101,7 +101,7 @@ def main():
                         level=logging.INFO,
                         stream=sys.stdout)
 
-    print('\nBegin script.py')
+    print('\nscript.py: starting')
     with open('/builds/worker/version') as versionfile:
         version = versionfile.read().strip()
     print('\nDockerfile version {}'.format(version))
@@ -211,7 +211,7 @@ def main():
         while written < line_bytelen:
             written += sys.stdout.write(str(line))
         rc = proc.poll()
-    print("script.py payload command finished")
+    print("script.py: payload command finished")
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324
@@ -234,7 +234,7 @@ def main():
 
     show_df()
 
-    print('script.py exitcode {}'.format(rc))
+    print('script.py: exiting with exitcode {}.'.format(rc))
     return rc
 
 if __name__ == "__main__":

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -53,7 +53,7 @@ def get_device_type(device):
 
 
 def enable_charging(device, device_type):
-    print("script.py: enabling charging...")
+    print("script.py: enabling charging for %s (%s)..." % (device, device_type))
     p2_path = "/sys/class/power_supply/battery/input_suspend"
     g5_path = "/sys/class/power_supply/battery/charging_enabled"
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -37,7 +37,7 @@ def show_df():
     try:
         print('\df -h\n%s\n\n' % subprocess.check_output(
             ['df', '-h'],
-            stderr=subprocess.STDOUT))
+            stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting df'.format(e))
 
@@ -236,7 +236,7 @@ def main():
     try:
         print('\nnetstat -aop\n%s\n\n' % subprocess.check_output(
             ['netstat', '-aop'],
-            stderr=subprocess.STDOUT))
+            stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting netstat'.format(e))
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -53,6 +53,7 @@ def get_device_type(device):
 
 
 def enable_charging(device, device_type):
+    print("script.py: enabling charging...")
     p2_path = "/sys/class/power_supply/battery/input_suspend"
     g5_path = "/sys/class/power_supply/battery/charging_enabled"
 
@@ -210,6 +211,7 @@ def main():
         while written < line_bytelen:
             written += (sys.stdout.write(line) or 0)
         rc = proc.poll()
+    print("script.py payload command finished")
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -217,6 +217,7 @@ def main():
         rc = proc.poll()
         if line:
             bytes_written += sys.stdout.write(str(line.decode()))
+        # print("ll: %s, bw: %s, br: %s, rc: %s" % (line_len, bytes_written, bytes_read, rc))
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -199,13 +199,13 @@ def main():
     # run the payload's command
     print(' '.join(extra_args))
     rc = None
+    read = 0
+    written = 0
     proc = subprocess.Popen(extra_args,
                             bufsize=0,
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
-    read = 0
-    written = 0
     while True:
         output = proc.stdout.readline()
         line_len = len(output)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1595129 for background.

changes:
- ensure the full line has been written
- add additional debugging output to determine where this script might be hanging
- upgrade to mozdevice 3.0.6 for py3 compatibility
- pin docker image to a digest value
  - https://medium.com/@tariq.m.islam/container-deployments-a-lesson-in-deterministic-ops-a4a467b14a03

Test plan:
- Build locally and ensure script.py and entrypoint.sh run.
  - Working.
- Build an image from this branch and do initial Bitbar testing.
  - test links below

Images built from this PR/branch: 
- fce77ad : `Successfully tagged mozilla-image:20191114T161717`, https://mozilla.testdroid.com/#testing/device-session/1328432/1385525/35780048
  - tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=1635c9df8268cbe29f6551ef7cc2b665c95a4a60
- 471e227 : `Successfully tagged mozilla-image:20191119T130125`, https://mozilla.testdroid.com/#testing/test-run/1328432/1403186
  - tests
    - g5: https://treeherder.mozilla.org/#/jobs?repo=try&revision=4f042d80ceab83b3af76d8a75e13424cc006c596
    - p2: https://treeherder.mozilla.org/#/jobs?repo=try&revision=3b84ad0f30e53f2e4a2b7771981b4ae4a7443f1c

reference try pushes:
- g5: https://treeherder.mozilla.org/#/jobs?repo=try&revision=575f1f6057604350ca583bdea6e92dbaa2ea9b22
- p2: https://treeherder.mozilla.org/#/jobs?repo=try&revision=bfe03f683fc6b8e38d5829b755f6172561de2206