### PR TITLE
fix livelogging

### DIFF
--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -13,6 +13,6 @@
     "workerGroup":                "${TC_WORKER_GROUP}",
     "workerId":                   "${DEVICE_NAME}",
     "workerType":                 "${TC_WORKER_TYPE}",
-    "wstAudience":                "taskcluster-net",
+    "wstAudience":                "firefoxcitc",
     "wstServerURL":               "https://websocktunnel.tasks.build"
 }


### PR DESCRIPTION
Set wstAudience to firefoxcitc (per tomprince). Has been broken since TCW.
