### PR TITLE
handle ADBTimeout exceptions in script.py

### DIFF
--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -161,9 +161,11 @@ def main():
         devices = adbhost.devices()
         print(json.dumps(devices, indent=4))
         if len(devices) != 1:
-            fatal('Must have exactly one connected device. {} found.'.format(len(devices)))
+            fatal('Must have exactly one connected device. {} found.'.format(len(devices)), retry=True)
+    except ADBTimeoutError as e:
+        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
     except ADBError as e:
-        fatal('{} Unable to obtain attached devices'.format(e))
+        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
 
     try:
         for f in glob('/tmp/adb.*.log'):

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -197,7 +197,7 @@ def main():
     except ADBError as e:
         fatal("{} attempting to clean up device".format(e), retry=True)
     except ADBTimeoutError as e:
-        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
+        fatal("{} attempting to clean up device".format(e), retry=True)
 
     if taskcluster_debug:
         env['DEBUG'] = taskcluster_debug

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -235,7 +235,9 @@ def main():
             adbhost.command_output(["disconnect", env['DEVICE_SERIAL']])
         adbhost.kill_server()
     except ADBError as e:
-        print('{} attempting adb kill-server'.format(e))
+        print('{} attempting adb kill-server'.format(e), retry=True)
+    except ADBError as e:
+        print('{} attempting adb kill-server'.format(e), retry=True)
 
     try:
         print('\nnetstat -aop\n%s\n\n' % subprocess.check_output(

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -162,9 +162,7 @@ def main():
         print(json.dumps(devices, indent=4))
         if len(devices) != 1:
             fatal('Must have exactly one connected device. {} found.'.format(len(devices)), retry=True)
-    except ADBError as e:
-        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
-    except ADBTimeoutError as e:
+    except (ADBError, ADBTimeoutError) as e:
         fatal('{} Unable to obtain attached devices'.format(e), retry=True)
 
     try:
@@ -194,9 +192,7 @@ def main():
         device.rm('/data/local/tmp/xpcb', recursive=True, force=True, root=True)
         device.rm('/sdcard/tests', recursive=True, force=True, root=True)
         device.rm('/sdcard/raptor-profile', recursive=True, force=True, root=True)
-    except ADBError as e:
-        fatal("{} attempting to clean up device".format(e), retry=True)
-    except ADBTimeoutError as e:
+    except (ADBError, ADBTimeoutError) as e:
         fatal("{} attempting to clean up device".format(e), retry=True)
 
     if taskcluster_debug:
@@ -234,9 +230,7 @@ def main():
             device.command_output(["usb"])
             adbhost.command_output(["disconnect", env['DEVICE_SERIAL']])
         adbhost.kill_server()
-    except ADBError as e:
-        print('{} attempting adb kill-server'.format(e))
-    except ADBError as e:
+    except (ADBError, ADBTimeoutError) as e:
         print('{} attempting adb kill-server'.format(e))
 
     try:

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -154,7 +154,7 @@ def main():
     # to connect to the device. DEVICE_SERIAL will be set to either
     # the device's serial number or its ipaddress:5555 by the framework.
     try:
-        adbhost = ADBHost()
+        adbhost = ADBHost(verbose=True)
         if env['DEVICE_SERIAL'].endswith(':5555'):
             # Power testing with adb over wifi.
             adbhost.command_output(["connect", env['DEVICE_SERIAL']])

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -235,9 +235,9 @@ def main():
             adbhost.command_output(["disconnect", env['DEVICE_SERIAL']])
         adbhost.kill_server()
     except ADBError as e:
-        print('{} attempting adb kill-server'.format(e), retry=True)
+        print('{} attempting adb kill-server'.format(e))
     except ADBError as e:
-        print('{} attempting adb kill-server'.format(e), retry=True)
+        print('{} attempting adb kill-server'.format(e))
 
     try:
         print('\nnetstat -aop\n%s\n\n' % subprocess.check_output(

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -195,7 +195,7 @@ def main():
         device.rm('/sdcard/tests', recursive=True, force=True, root=True)
         device.rm('/sdcard/raptor-profile', recursive=True, force=True, root=True)
     except ADBError as e:
-        fatal("{} attempting to clean up device".format(e))
+        fatal("{} attempting to clean up device".format(e), retry=True)
     except ADBTimeoutError as e:
         fatal('{} Unable to obtain attached devices'.format(e), retry=True)
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -162,9 +162,9 @@ def main():
         print(json.dumps(devices, indent=4))
         if len(devices) != 1:
             fatal('Must have exactly one connected device. {} found.'.format(len(devices)), retry=True)
-    except ADBTimeoutError as e:
-        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
     except ADBError as e:
+        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
+    except ADBTimeoutError as e:
         fatal('{} Unable to obtain attached devices'.format(e), retry=True)
 
     try:
@@ -196,6 +196,8 @@ def main():
         device.rm('/sdcard/raptor-profile', recursive=True, force=True, root=True)
     except ADBError as e:
         fatal("{} attempting to clean up device".format(e))
+    except ADBTimeoutError as e:
+        fatal('{} Unable to obtain attached devices'.format(e), retry=True)
 
     if taskcluster_debug:
         env['DEBUG'] = taskcluster_debug


### PR DESCRIPTION
also:
- change existing exception handling to return exit code on ADB* exceptions
- ADBHost is set to verbose mode (https://github.com/bclary/mozilla-bitbar-docker/issues/16)

see https://bugzilla.mozilla.org/show_bug.cgi?id=1597364