### PR TITLE
fix for unicode strings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 # Set variables normally configured at login, by the shells parent process, these
 # are taken from GNU su manual
+# - PYTHONIOENCODING is set so that unicode characters can be output
+#   - see https://bugzilla.mozilla.org/show_bug.cgi?id=1600833
 
 ENV    HOME=/builds/worker \
        SHELL=/bin/bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ ENV    HOME=/builds/worker \
        LANGUAGE=en_US.UTF-8 \
        LANG=en_US.UTF-8 \
        LC_ALL=en_US.UTF-8 \
+       PYTHONIOENCODING=utf-8 \
        PATH=$PATH:/builds/worker/bin
 
 # download things

--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -32,6 +32,7 @@ def dump_scriptvars():
         "HOST_IP",
         "HOSTNAME",
         "PATH",
+        "PYTHONIOENCODING",
         "TC_WORKER_GROUP",
         "TC_WORKER_TYPE",
         "TESTDROID_BUILD_ID",

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -212,11 +212,12 @@ def main():
                             stderr=subprocess.STDOUT)
     while True:
         line = proc.stdout.readline()
-        line_len = len(line)
+        decoded_line = line.decode()
+        line_len = len(decoded_line)
         bytes_read += line_len
         rc = proc.poll()
         if line:
-            bytes_written += sys.stdout.write(str(line.decode()))
+            bytes_written += sys.stdout.write(decoded_line)
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))


### PR DESCRIPTION
Attempt to fix errors seen in https://bugzilla.mozilla.org/show_bug.cgi?id=1600833 (J1 test failures due to unicode in output). Bug was introduced in https://github.com/bclary/mozilla-bitbar-docker/pull/31.

Local testing done:
- https://mana.mozilla.org/wiki/display/ROPS/Android+Infrastructure#AndroidInfrastructure-TestingNewDockerImagesLocally

Images built from this branch:
- c633501: `20191203T130316`
  - https://mozilla.testdroid.com/#testing/device-session/1328436/1462434/38252014
    - problem: still has unicode errors
      - p2 jsreftests (includes J1 test in bug): https://treeherder.mozilla.org/#/jobs?repo=try&revision=fe980dd57b22a2814f99b85540e5341c5e40caa4
      - g5 normal tests I usually run: https://treeherder.mozilla.org/#/jobs?repo=try&revision=c25276eec6b7b6737a9c2aa8a053e25cd03d610e
- e348c8d : `20191206T165443`
  - `12-06 17:00:20.847 Successfully tagged mozilla-image:20191206T165443`
    - https://mozilla.testdroid.com/#testing/device-session/1328436/1476895/38703367
    - problem: PYTHONIOENCODING didn't reach script.py due to env filtering
      - https://treeherder.mozilla.org/#/jobs?repo=try&revision=91fed0c51891789210686c6a05b4a1c9d6ac719f
- e6098ea : `20191209T170558`
  - https://mozilla.testdroid.com/#testing/device-session/1328436/1486659/39021585
  - test results: WORKING
    - p2 tests (incl. failing in bug): https://treeherder.mozilla.org/#/jobs?repo=try&group_state=expanded&selectedJob=280421971&revision=b9a7c75b0557fe9eeb06ed903209739ac3bb62cc
    - g5 normal test: https://treeherder.mozilla.org/#/jobs?repo=try&revision=347d5f106898ee0046cd7f7327c0377f68f29856