### PR TITLE
fix livelogging attempt 2: also change wstServerUrl

### DIFF
--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -14,5 +14,5 @@
     "workerId":                   "${DEVICE_NAME}",
     "workerType":                 "${TC_WORKER_TYPE}",
     "wstAudience":                "firefoxcitc",
-    "wstServerURL":               "https://websocktunnel.tasks.build"
+    "wstServerURL":               "https://firefoxci-websocktunnel.services.mozilla.com/"
 }


### PR DESCRIPTION
The latest test image isn't livelogging yet. Tom Prince mentioned I need to set wstServerUrl also. 

Follow up to https://github.com/bclary/mozilla-bitbar-docker/pull/32/files.

see https://hg.mozilla.org/ci/ci-configuration/file/tip/worker-pools.yml#l44