### PR TITLE
add taskcluster-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ COPY scripts/tooltool.py /usr/local/bin/tooltool.py
 RUN cd /tmp && \
     chmod +x /usr/local/bin/generic-worker && \
     chmod +x /usr/local/bin/livelog && \
+    chmod +x /usr/local/bin/taskcluster-proxy && \
     chmod +x /usr/local/bin/tooltool.py && \
     chmod +x /usr/local/bin/entrypoint.* && \
     chmod +x /builds/taskcluster/script.py && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,16 +76,18 @@ ENV    HOME=/builds/worker \
 # download things
 ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 ADD https://dl.google.com/android/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
 ADD https://github.com/taskcluster/generic-worker/releases/download/v16.0.0/generic-worker-simple-linux-amd64 /usr/local/bin/generic-worker
 ADD https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-linux-amd64 /usr/local/bin/livelog
-ADD https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+ADD https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-linux-amd64 /usr/local/bin/taskcluster-proxy
 
 # for testing builds (these lines mirror above), copy above artifacts from the downloads dir
 # COPY downloads/node-v8.11.3-linux-x64.tar.gz /builds/worker/Downloads
 # COPY downloads/android-sdk_r24.3.4-linux.tgz /builds/worker/Downloads
+# COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
 # COPY downloads/generic-worker-nativeEngine-linux-amd64 /usr/local/bin/generic-worker
 # COPY downloads/livelog-linux-amd64 /usr/local/bin/livelog
-# COPY downloads/sdk-tools-linux-4333796.zip /builds/worker/Downloads
+# COPY downloads/taskcluster-proxy-linux-amd64 /usr/local/bin/taskcluster-proxy
 
 # copy stackdriver credentials over
 COPY stackdriver_credentials.json /etc/google/stackdriver_credentials.json

--- a/taskcluster/generic-worker.yml.template
+++ b/taskcluster/generic-worker.yml.template
@@ -10,6 +10,7 @@
     "publicIP":                   "127.0.0.1",
     "requiredDiskSpaceMegabytes": 6500,
     "rootURL":                    "https://firefox-ci-tc.services.mozilla.com",
+    "taskclusterProxyPort":       8099,
     "workerGroup":                "${TC_WORKER_GROUP}",
     "workerId":                   "${DEVICE_NAME}",
     "workerType":                 "${TC_WORKER_TYPE}",


### PR DESCRIPTION
Also set a non-80 port.

Tested locally and g-w seems to be happy.

```
eb811106755f: 2019/12/18 20:04:10 UTC Detected linux platform
eb811106755f: 2019/12/18 20:04:10 UTC Detected simple engine
eb811106755f: 2019/12/18 20:04:10 UTC Initialising task feature Live Log...
eb811106755f: 2019/12/18 20:04:10 UTC Initialising task feature Taskcluster Proxy...
eb811106755f: 2019/12/18 20:04:10 UTC Initialising task feature OS Groups...
eb811106755f: 2019/12/18 20:04:10 UTC Initialising task feature Mounts/Caches...
eb811106755f: 2019/12/18 20:04:10 UTC Loaded file file-caches.json
eb811106755f: 2019/12/18 20:04:10 UTC Loaded file directory-caches.json
eb811106755f: 2019/12/18 20:04:10 UTC Initialising task feature Supersede...
eb811106755f: 2019/12/18 20:04:10 UTC All features initialised.
eb811106755f: 2019/12/18 20:04:10 UTC Created dir: /builds/task_1576699450/generic-worker
eb811106755f: 2019/12/18 20:04:10 UTC Removing directory '/builds/task_1576631671'...
eb811106755f: 2019/12/18 20:04:10 UTC Disk available: 24906887168 bytes
```

see https://bugzilla.mozilla.org/show_bug.cgi?id=1599625