### PR TITLE
handle ADBTimeout in a debug message

### DIFF
--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -88,11 +88,9 @@ def enable_charging(device, device_type):
             pass
         else:
             fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
-    except ADBError as e:
-        fatal("Failed to enable charging. Contact Android Relops immediately.", exception=e, retry=False)
-    except ADBTimeoutError as e:
+    except (ADBError, ADBTimeoutError) as e:
         print(
-            "TEST-WARNING | bitbar | Timed out trying to enable charging."
+            "TEST-WARNING | bitbar | Error while attempting to enable charging."
         )
         print("{}: {}".format(e.__class__.__name__, e))
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -55,11 +55,11 @@ def get_device_type(device):
 
 
 def enable_charging(device, device_type):
-    print("script.py: enabling charging for device '%s' ('%s')..." % (device_type, device.get_info('id')['id']))
     p2_path = "/sys/class/power_supply/battery/input_suspend"
     g5_path = "/sys/class/power_supply/battery/charging_enabled"
 
     try:
+        print("script.py: enabling charging for device '%s' ('%s')..." % (device_type, device.get_info('id')['id']))
         if device_type == "Pixel 2":
             p2_charging_disabled = (
                 device.shell_output(


### PR DESCRIPTION
```
[task 2019-12-18T20:20:05.722Z] Traceback (most recent call last):
[task 2019-12-18T20:20:05.722Z]   File "/builds/taskcluster/script.py", line 250, in <module>
[task 2019-12-18T20:20:05.722Z]     sys.exit(main())
[task 2019-12-18T20:20:05.722Z]   File "/builds/taskcluster/script.py", line 227, in main
[task 2019-12-18T20:20:05.722Z]     enable_charging(device, device_type)
[task 2019-12-18T20:20:05.722Z]   File "/builds/taskcluster/script.py", line 58, in enable_charging
[task 2019-12-18T20:20:05.722Z]     print("script.py: enabling charging for device '%s' ('%s')..." % (device_type, device.get_info('id')['id']))
[task 2019-12-18T20:20:05.722Z]   File "/usr/local/lib/python3.6/dist-packages/mozdevice/adb.py", line 2883, in get_info
[task 2019-12-18T20:20:05.722Z]     info['id'] = self.command_output(['get-serialno'], timeout=timeout)
[task 2019-12-18T20:20:05.722Z]   File "/usr/local/lib/python3.6/dist-packages/mozdevice/adb.py", line 1215, in command_output
[task 2019-12-18T20:20:05.722Z]     timeout=timeout)
[task 2019-12-18T20:20:05.722Z]   File "/usr/local/lib/python3.6/dist-packages/mozdevice/adb.py", line 318, in command_output
[task 2019-12-18T20:20:05.722Z]     raise ADBTimeoutError("%s" % adb_process)
[task 2019-12-18T20:20:05.722Z] mozdevice.adb.ADBTimeoutError: args: adb wait-for-device get-serialno, exitcode: None, stdout: 
```