### PR TITLE
add logcat logging and timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 downloads/
 *.pyc
 stackdriver_credentials.json
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     net-tools \
     netcat \
     openjdk-8-jdk-headless \
+    psmisc \ 
     python \
     python-pip \
     python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
     sudo \
     tzdata \
     unzip \
+    vim \
     wget \
     xvfb \
     zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     net-tools \
     netcat \
     openjdk-8-jdk-headless \
-    psmisc \ 
+    psmisc \
     python \
     python-pip \
     python3 \
@@ -37,7 +37,6 @@ RUN apt-get update && \
     sudo \
     tzdata \
     unzip \
-    vim \
     wget \
     xvfb \
     zip \

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -19,6 +19,7 @@ from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 
 MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
+TIMEOUT_MINUTES = 44
 
 
 class DebugPrinter:
@@ -69,7 +70,7 @@ def timeout(time):
 
 
 def raise_timeout(signum, frame):
-    print("script.py: timeout")
+    print("script.py: timeout at %s minutes" % TIMEOUT_MINUTES)
     subprocess.call(["/usr/bin/pstree", "-pct"])
     raise TimeoutError
 
@@ -89,6 +90,7 @@ def fatal(message, exception=None, retry=True):
         print("{}: {}".format(exception.__class__.__name__, exception))
     sys.exit(exit_code)
 
+
 def show_df():
     try:
         print('\ndf -h\n%s\n\n' % subprocess.check_output(
@@ -96,6 +98,7 @@ def show_df():
             stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting df'.format(e))
+
 
 def get_device_type(device):
     device_type = device.shell_output("getprop ro.product.model", timeout=ADB_COMMAND_TIMEOUT)
@@ -149,6 +152,7 @@ def enable_charging(device, device_type):
             "TEST-WARNING | bitbar | Error while attempting to enable charging."
         )
         print("{}: {}".format(e.__class__.__name__, e))
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -260,8 +264,8 @@ def main():
     bytes_read = 0
     bytes_written = 0
     dpi = DebugPrinter(device)
-    # timeout in 44 minutes
-    with timeout(44 * 60):
+    # timeout in x minutes
+    with timeout(TIMEOUT_MINUTES * 60):
         proc = subprocess.Popen(extra_args,
                                 bufsize=0,
                                 env=env,

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -68,12 +68,10 @@ def timeout(time):
         # if the timeout is not reached.
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
-
 def raise_timeout(signum, frame):
     print("script.py: timeout at %s minutes" % TIMEOUT_MINUTES)
     subprocess.call(["/usr/bin/pstree", "-pct"])
     raise TimeoutError
-
 
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
@@ -90,7 +88,6 @@ def fatal(message, exception=None, retry=True):
         print("{}: {}".format(exception.__class__.__name__, exception))
     sys.exit(exit_code)
 
-
 def show_df():
     try:
         print('\ndf -h\n%s\n\n' % subprocess.check_output(
@@ -98,7 +95,6 @@ def show_df():
             stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting df'.format(e))
-
 
 def get_device_type(device):
     device_type = device.shell_output("getprop ro.product.model", timeout=ADB_COMMAND_TIMEOUT)
@@ -111,7 +107,6 @@ def get_device_type(device):
     else:
         fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     return device_type
-
 
 def enable_charging(device, device_type):
     p2_path = "/sys/class/power_supply/battery/input_suspend"
@@ -152,7 +147,6 @@ def enable_charging(device, device_type):
             "TEST-WARNING | bitbar | Error while attempting to enable charging."
         )
         print("{}: {}".format(e.__class__.__name__, e))
-
 
 def main():
     parser = argparse.ArgumentParser(

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -68,7 +68,7 @@ def timeout(time):
 
 def raise_timeout(signum, frame):
     print("script.py: timeout")
-    subprocess.call("pstree -pct")
+    subprocess.call(["/usr/bin/pstree", "-pct"])
     raise TimeoutError
 
 def fatal(message, exception=None, retry=True):
@@ -257,7 +257,8 @@ def main():
     bytes_read = 0
     bytes_written = 0
     dpi = DebugPrinter(device)
-    with timeout(35):
+    # timeout in 44 minutes
+    with timeout(44 * 60):
         proc = subprocess.Popen(extra_args,
                                 bufsize=0,
                                 env=env,

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -37,7 +37,7 @@ class DebugPrinter:
 
     def print_to_logcat(self, a_string, print_to_screen_also=True):
         elapsed = self.get_elapsed_time()
-        msg = "script.py: %s:+%s: %s'" % (self.get_start_time(), elapsed, a_string)
+        msg = "script.py: %s:+%s: %s" % (self.get_start_time(), elapsed, a_string)
         if print_to_screen_also:
             print(msg)
         self.adb_device.shell_output("log '%s'" % msg)

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -20,7 +20,7 @@ from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 
 MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
-TIMEOUT_MINUTES = 44
+TIMEOUT_MINUTES = 10
 
 
 class DebugPrinter:

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -50,10 +50,9 @@ class DebugPrinter:
 
     def raise_timeout(self, signum, frame):
         msg = "timeout at %s minutes" % TIMEOUT_MINUTES
-        print("script.py:" + msg)
         self.print_to_logcat(msg)
-        # TODO: capture and send to logcat
-        subprocess.call(["/usr/bin/pstree", "-pct"])
+        output = subprocess.getoutput(["/usr/bin/pstree", "-pct"])
+        self.print_to_logcat(output)
         raise MyTimeoutError
 
 
@@ -293,13 +292,11 @@ def main():
                 while temp_bytes_written != line_len:
                     temp_bytes_written += sys.stdout.write(decoded_line)
                     if temp_bytes_written != line_len:
-                        print("script.py: sys.stdout.write underwrite (%d vs %d)!" % (temp_bytes_written, line_len))
                         dpi.print_to_logcat("print underwrite: %d %d'" % (temp_bytes_written, line_len))
                 bytes_written += temp_bytes_written
             dpi.print_to_logcat_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
             if line_len == 0 and bytes_written == bytes_read and rc is not None:
                 break
-    print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))
     dpi.print_to_logcat("command finished: ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
 
     # enable charging on device if it is disabled

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -19,6 +19,31 @@ MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
 
 
+class DebugPrinter:
+
+    def __init__(self, device, seconds_to_wait_between_print=10):
+        self.start_time = time.time()
+        self.last_log_print_time = self.start_time
+        self.adb_device = device
+        self.seconds_to_wait = seconds_to_wait_between_print
+
+    def get_elapsed_time(self):
+        return time.time() - self.start_time
+
+    def get_start_time(self):
+        return self.start_time
+
+    def print_to_logcat(self, a_string):
+        elapsed = self.get_elapsed_time()
+        self.adb_device.shell_output("log 'script.py: %s:+%s: %s'" % (self.get_start_time(), elapsed, a_string))
+
+    def print_to_logcat_interval(self, a_string):
+        now = time.time()
+        if now >= (self.last_log_print_time + self.seconds_to_wait):
+            self.last_log_print_time = now
+            self.print_to_logcat(a_string)
+
+
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
     TBPL_RETRY_EXIT_STATUS this will cause the job to be retried.
@@ -204,8 +229,7 @@ def main():
     rc = None
     bytes_read = 0
     bytes_written = 0
-    debug_start = time.time()
-    last_debug_log_time = debug_start
+    dpi = DebugPrinter(device)
     proc = subprocess.Popen(extra_args,
                             bufsize=0,
                             env=env,
@@ -225,15 +249,11 @@ def main():
                     print("script.py: sys.stdout.write underwrite (%d vs %d)!" % (temp_bytes_written, line_len))
                     device.shell_output("log 'script.py: print underwrite: %d %d'" % (temp_bytes_written, line_len))
             bytes_written += temp_bytes_written
-        # if the last debug log was > 10 seconds ago, print now
-        now = time.time()
-        if now >= last_debug_log_time + 10:
-            elapsed = now - debug_start
-            last_debug_log_time = now
-            device.shell_output("log 'script.py: print debug +%s: ll:%s bw:%s br:%s rc:%s'" % (elapsed, line_len, bytes_written, bytes_read, rc))
+        dpi.print_to_logcat_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))
+    dpi.print_to_logcat("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -41,7 +41,7 @@ class DebugPrinter:
         msg = "script.py: %s:+%s: %s" % (self.get_start_time(), elapsed, a_string)
         if print_to_screen_also:
             print(msg)
-        self.adb_device.shell_output("log %s" % msg)
+        self.adb_device.shell_output("log %s" % shlex.quote(msg))
 
     def print_to_logcat_interval(self, a_string):
         now = time.time()
@@ -52,8 +52,7 @@ class DebugPrinter:
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
         output = subprocess.getoutput("/usr/bin/pstree -aApct")
-        fixed_output = shlex.quote(output)
-        self.print_to_logcat("pstree: \n" + fixed_output + "\n")
+        self.print_to_logcat("pstree: \n" + output + "\n")
         raise MyTimeoutError
 
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -51,7 +51,7 @@ class DebugPrinter:
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
         output = subprocess.getoutput("/usr/bin/pstree -aApct")
-        self.print_to_logcat(output)
+        self.print_to_logcat("pstree: \n" + output + "\n")
         raise MyTimeoutError
 
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -254,7 +254,7 @@ def main():
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))
-    dpi.print_to_logcat("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
+    dpi.print_to_logcat("command finished: ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -8,12 +8,12 @@ import argparse
 import json
 import logging
 import os
+import signal
 import subprocess
 import sys
 import time
-from glob import glob
-import signal
 from contextlib import contextmanager
+from glob import glob
 
 from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -274,25 +274,31 @@ def main():
                                 bufsize=0,
                                 env=env,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
+                                stderr=subprocess.STDOUT,
+                                close_fds=True)
         dpi.debug_print("command started")
-        while True:
-            line = proc.stdout.readline()
-            decoded_line = line.decode()
-            line_len = len(decoded_line)
-            bytes_read += line_len
-            rc = proc.poll()
-            if line:
-                temp_bytes_written = 0
-                while temp_bytes_written < line_len:
-                    temp_bytes_written += sys.stdout.write(decoded_line)
-                    if temp_bytes_written < line_len:
-                        dpi.debug_print("print underwrite: %d %d'" % (temp_bytes_written, line_len))
-                bytes_written += temp_bytes_written
-            dpi.debug_print_at_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
-            if line_len == 0 and bytes_written == bytes_read and rc is not None:
-                break
-    dpi.debug_print("command finished: ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
+        #### MEGA SIMPLIFIED
+        for line in proc.stdout:
+            print(line.decode())
+        #### OLD CODE
+        # while True:
+        #     line = proc.stdout.readline()
+        #     decoded_line = line.decode()
+        #     line_len = len(decoded_line)
+        #     bytes_read += line_len
+        #     rc = proc.poll()
+        #     if line:
+        #         bytes_written += sys.stdout.write(decoded_line)
+        #         # temp_bytes_written = 0
+        #         # while temp_bytes_written < line_len:
+        #         #     temp_bytes_written += sys.stdout.write(decoded_line)
+        #         #     if temp_bytes_written < line_len:
+        #         #         dpi.debug_print("print underwrite: %d %d'" % (temp_bytes_written, line_len))
+        #         # bytes_written += temp_bytes_written
+        #     dpi.debug_print_at_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
+        #     if rc is not None:
+        #         break
+    dpi.debug_print("command finished") #: ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -278,9 +278,9 @@ def main():
             rc = proc.poll()
             if line:
                 temp_bytes_written = 0
-                while temp_bytes_written != line_len:
+                while temp_bytes_written <= line_len:
                     temp_bytes_written += sys.stdout.write(decoded_line)
-                    if temp_bytes_written != line_len:
+                    if temp_bytes_written <= line_len:
                         dpi.print_to_logcat("print underwrite: %d %d'" % (temp_bytes_written, line_len))
                 bytes_written += temp_bytes_written
             dpi.print_to_logcat_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -49,7 +49,7 @@ class DebugPrinter:
             self.print_to_logcat(a_string)
 
     def raise_timeout(self, signum, frame):
-        self.print_to_logcat("timeout at %s minutes" % TIMEOUT_MINUTES)
+        self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
         output = subprocess.getoutput("/usr/bin/pstree -pct")
         self.print_to_logcat(output)
         raise MyTimeoutError

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -20,7 +20,7 @@ from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 
 MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
-TIMEOUT_MINUTES = 1
+TIMEOUT_MINUTES = 44
 
 
 class DebugPrinter:

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -218,6 +218,8 @@ def main():
             temp_bytes_written = 0
             while temp_bytes_written != line_len:
                 temp_bytes_written += sys.stdout.write(decoded_line)
+                if temp_bytes_written != line_len:
+                    print("script.py: sys.stdout.write underwrite (%d vs %d)!" % (temp_bytes_written, line_len))
             bytes_written += temp_bytes_written
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -263,7 +263,7 @@ def main():
 
     # run the payload's command
     print("script.py: running command '%s'" % ' '.join(extra_args))
-    rc = 1
+    rc = None
     bytes_read = 0
     bytes_written = 0
     dpi = DebugPrinter(device)

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -49,8 +49,7 @@ class DebugPrinter:
             self.print_to_logcat(a_string)
 
     def raise_timeout(self, signum, frame):
-        msg = "timeout at %s minutes" % TIMEOUT_MINUTES
-        self.print_to_logcat(msg)
+        self.print_to_logcat("timeout at %s minutes" % TIMEOUT_MINUTES)
         output = subprocess.getoutput(["/usr/bin/pstree", "-pct"])
         self.print_to_logcat(output)
         raise MyTimeoutError

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -49,6 +49,7 @@ class DebugPrinter:
 class TimeoutError(Exception):
     pass
 
+
 @contextmanager
 def timeout(time):
     # Register a function to raise a TimeoutError on the signal.
@@ -64,7 +65,6 @@ def timeout(time):
         # Unregister the signal so it won't be triggered
         # if the timeout is not reached.
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
-
 
 def raise_timeout(signum, frame):
     print("script.py: timeout")

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -50,7 +50,7 @@ class DebugPrinter:
 
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
-        output = subprocess.getoutput("/usr/bin/pstree -pct")
+        output = subprocess.getoutput("/usr/bin/pstree -aApct")
         self.print_to_logcat(output)
         raise MyTimeoutError
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -315,6 +315,10 @@ def main():
 
     show_df()
 
+    if rc is None:
+        print("script.py: setting exit code to 1 due to timeout")
+        rc = 1
+
     print('script.py: exiting with exitcode {}.'.format(rc))
     return rc
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -235,7 +235,7 @@ def main():
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
-    dpi.print_to_logcat("script.py: command started")
+    dpi.print_to_logcat("command started")
     while True:
         line = proc.stdout.readline()
         decoded_line = line.decode()

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -262,7 +262,7 @@ def main():
 
     # run the payload's command
     print("script.py: running command '%s'" % ' '.join(extra_args))
-    rc = None
+    rc = 1
     bytes_read = 0
     bytes_written = 0
     dpi = DebugPrinter(device)

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -282,6 +282,7 @@ def main():
             dpi.debug_print_at_interval("checkpoint")
             # print(line.decode().rstrip())
             sys.stdout.write(line.decode())
+        rc = proc.poll()
         #### OLD CODE
         # while True:
         #     line = proc.stdout.readline()

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -50,7 +50,7 @@ class DebugPrinter:
 
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minutes" % TIMEOUT_MINUTES)
-        output = subprocess.getoutput(["/usr/bin/pstree", "-pct"])
+        output = subprocess.getoutput("/usr/bin/pstree -pct")
         self.print_to_logcat(output)
         raise MyTimeoutError
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -76,12 +76,6 @@ def timeout(timeout_seconds, a_dpi):
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
 
-# def raise_timeout(signum, frame):
-#     print("script.py: timeout at %s minutes" % TIMEOUT_MINUTES)
-#     subprocess.call(["/usr/bin/pstree", "-pct"])
-#     raise MyTimeoutError
-
-
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
     TBPL_RETRY_EXIT_STATUS this will cause the job to be retried.

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -40,7 +41,7 @@ class DebugPrinter:
         msg = "script.py: %s:+%s: %s" % (self.get_start_time(), elapsed, a_string)
         if print_to_screen_also:
             print(msg)
-        self.adb_device.shell_output("log '%s'" % msg)
+        self.adb_device.shell_output("log %s" % msg)
 
     def print_to_logcat_interval(self, a_string):
         now = time.time()
@@ -51,7 +52,8 @@ class DebugPrinter:
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
         output = subprocess.getoutput("/usr/bin/pstree -aApct")
-        self.print_to_logcat("pstree: \n" + output + "\n")
+        fixed_output = shlex.quote(output)
+        self.print_to_logcat("pstree: \n" + fixed_output + "\n")
         raise MyTimeoutError
 
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -235,6 +235,7 @@ def main():
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
+    dpi.print_to_logcat("script.py: command started")
     while True:
         line = proc.stdout.readline()
         decoded_line = line.decode()
@@ -247,7 +248,7 @@ def main():
                 temp_bytes_written += sys.stdout.write(decoded_line)
                 if temp_bytes_written != line_len:
                     print("script.py: sys.stdout.write underwrite (%d vs %d)!" % (temp_bytes_written, line_len))
-                    device.shell_output("log 'script.py: print underwrite: %d %d'" % (temp_bytes_written, line_len))
+                    dpi.print_to_logcat("print underwrite: %d %d'" % (temp_bytes_written, line_len))
             bytes_written += temp_bytes_written
         dpi.print_to_logcat_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))
         if line_len == 0 and bytes_written == bytes_read and rc is not None:

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -76,7 +76,6 @@ def timeout(timeout_seconds, a_dpi):
         # if the timeout is not reached.
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
-
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
     TBPL_RETRY_EXIT_STATUS this will cause the job to be retried.
@@ -92,7 +91,6 @@ def fatal(message, exception=None, retry=True):
         print("{}: {}".format(exception.__class__.__name__, exception))
     sys.exit(exit_code)
 
-
 def show_df():
     try:
         print('\ndf -h\n%s\n\n' % subprocess.check_output(
@@ -100,7 +98,6 @@ def show_df():
             stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting df'.format(e))
-
 
 def get_device_type(device):
     device_type = device.shell_output("getprop ro.product.model", timeout=ADB_COMMAND_TIMEOUT)
@@ -113,7 +110,6 @@ def get_device_type(device):
     else:
         fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     return device_type
-
 
 def enable_charging(device, device_type):
     p2_path = "/sys/class/power_supply/battery/input_suspend"
@@ -154,7 +150,6 @@ def enable_charging(device, device_type):
             "TEST-WARNING | bitbar | Error while attempting to enable charging."
         )
         print("{}: {}".format(e.__class__.__name__, e))
-
 
 def main():
     parser = argparse.ArgumentParser(

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -292,6 +292,8 @@ def main():
         dpi.debug_print("command started")
 
         #### non-blocking
+        # see https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options
+
         # Create the queue instance
         q = queue.Queue()
         # Kick off the monitoring thread

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -278,9 +278,9 @@ def main():
             rc = proc.poll()
             if line:
                 temp_bytes_written = 0
-                while temp_bytes_written <= line_len:
+                while temp_bytes_written < line_len:
                     temp_bytes_written += sys.stdout.write(decoded_line)
-                    if temp_bytes_written <= line_len:
+                    if temp_bytes_written < line_len:
                         dpi.print_to_logcat("print underwrite: %d %d'" % (temp_bytes_written, line_len))
                 bytes_written += temp_bytes_written
             dpi.print_to_logcat_interval("ll:%s bw:%s br:%s rc:%s" % (line_len, bytes_written, bytes_read, rc))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -24,7 +24,7 @@ TIMEOUT_MINUTES = 44
 
 
 class DebugPrinter:
-    def __init__(self, device, seconds_to_wait_between_print=10):
+    def __init__(self, device, seconds_to_wait_between_print=20):
         self.start_time = time.time()
         self.last_log_print_time = self.start_time
         self.adb_device = device
@@ -48,12 +48,17 @@ class DebugPrinter:
         if now >= (self.last_log_print_time + self.seconds_to_wait):
             self.last_log_print_time = now
             self.print_to_logcat(a_string)
+            # show logcat output also
+            self.pstree_to_logcat()
 
     def raise_timeout(self, signum, frame):
         self.print_to_logcat("timeout at %s minute(s)" % TIMEOUT_MINUTES)
+        self.pstree_to_logcat()
+        raise MyTimeoutError
+
+    def pstree_to_logcat(self):
         output = subprocess.getoutput("/usr/bin/pstree -aApct")
         self.print_to_logcat("pstree: \n" + output + "\n")
-        raise MyTimeoutError
 
 
 class MyTimeoutError(Exception):

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -22,7 +22,6 @@ ADB_COMMAND_TIMEOUT = 10
 
 
 class DebugPrinter:
-
     def __init__(self, device, seconds_to_wait_between_print=10):
         self.start_time = time.time()
         self.last_log_print_time = self.start_time
@@ -37,7 +36,9 @@ class DebugPrinter:
 
     def print_to_logcat(self, a_string):
         elapsed = self.get_elapsed_time()
-        self.adb_device.shell_output("log 'script.py: %s:+%s: %s'" % (self.get_start_time(), elapsed, a_string))
+        self.adb_device.shell_output(
+            "log 'script.py: %s:+%s: %s'" % (self.get_start_time(), elapsed, a_string)
+        )
 
     def print_to_logcat_interval(self, a_string):
         now = time.time()
@@ -66,10 +67,12 @@ def timeout(time):
         # if the timeout is not reached.
         signal.signal(signal.SIGALRM, signal.SIG_IGN)
 
+
 def raise_timeout(signum, frame):
     print("script.py: timeout")
     subprocess.call(["/usr/bin/pstree", "-pct"])
     raise TimeoutError
+
 
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -215,7 +215,10 @@ def main():
         bytes_read += line_len
         rc = proc.poll()
         if line:
-            bytes_written += sys.stdout.write(decoded_line)
+            temp_bytes_written = 0
+            while temp_bytes_written != line_len:
+                temp_bytes_written += sys.stdout.write(decoded_line)
+            bytes_written += temp_bytes_written
         if line_len == 0 and bytes_written == bytes_read and rc is not None:
             break
     print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -279,7 +279,9 @@ def main():
         dpi.debug_print("command started")
         #### MEGA SIMPLIFIED
         for line in proc.stdout:
-            print(line.decode())
+            dpi.debug_print_at_interval("checkpoint")
+            # print(line.decode().rstrip())
+            sys.stdout.write(line.decode())
         #### OLD CODE
         # while True:
         #     line = proc.stdout.readline()


### PR DESCRIPTION
Debugging branch to test fixes for https://bugzilla.mozilla.org/show_bug.cgi?id=1611936.

#35 didn't reveal if script.py is the source of the hang (https://treeherder.mozilla.org/#/jobs?repo=try&revision=72e4a6def23410d0e371b9fb86a0c62df4e563cc).

Based on #35. Does the following:
- Add logcat logging to get insight into what the command is doing.
- Adds a timeout at 44 minutes. `pstree` will be shown.

```
02-08 06:36:02.361  6420  6420 I log     : script.py: 1581143762.9057271:+0.0016665458679199219: command started
02-08 06:36:12.402  6425  6425 I log     : script.py: 1581143762.9057271:+10.042171716690063: ll:4 bw:44 br:44 rc:None
02-08 06:36:22.445  6429  6429 I log     : script.py: 1581143762.9057271:+20.079461812973022: ll:4 bw:84 br:84 rc:None
02-08 06:36:32.480  6433  6433 I log     : script.py: 1581143762.9057271:+30.119335651397705: ll:4 bw:124 br:124 rc:None
02-08 06:36:42.514  6436  6436 I log     : script.py: 1581143762.9057271:+40.15351867675781: ll:4 bw:164 br:164 rc:None
02-08 06:36:52.546  6439  6439 I log     : script.py: 1581143762.9057271:+50.18122053146362: ll:4 bw:204 br:204 rc:None
02-08 06:37:02.366  6442  6442 I log     : script.py: 1581143762.9057271:+60.006245374679565: timeout at 1 minute(s)
02-08 06:37:02.475  6445  6445 I log     : script.py: 1581143762.9057271:+60.11710524559021: pstree: 
02-08 06:37:02.475  6445  6445 I log     : 'bash,1
02-08 06:37:02.475  6445  6445 I log     :   |-adb,15 -L tcp:5037 fork-server server --reply-fd 7
02-08 06:37:02.475  6445  6445 I log     :   |   |-{adb},16
02-08 06:37:02.475  6445  6445 I log     :   |   |-{adb},22
02-08 06:37:02.475  6445  6445 I log     :   |   |-{adb},23
02-08 06:37:02.475  6445  6445 I log     :   |   |-{client_socket_t},19
02-08 06:37:02.475  6445  6445 I log     :   |   `-{device poll},18
02-08 06:37:02.475  6445  6445 I log     :   `-python3,89 /builds/taskcluster/script.py /bin/bash -c for i in {1..90}; do echo "444"; sleep 1; done ## run script 10 times
02-08 06:37:02.475  6445  6445 I log     :       |-bash,190 -c for i in {1..90}; do echo "444"; sleep 1; done ## run script 10 times
02-08 06:37:02.475  6445  6445 I log     :       |   `-sleep,268 1
02-08 06:37:02.475  6445  6445 I log     :       `-sh,272 -c /usr/bin/pstree -aApct
02-08 06:37:02.475  6445  6445 I log     :           `-pstree,273 -aApct'
02-08 06:37:02.580  6448  6448 I log     : script.py: 1581143762.9057271:+60.22212743759155: command finished: ll:4 bw:240 br:240 rc:None
```