### PR TITLE
fix script.py hangs

### DIFF
--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -218,7 +218,9 @@ def main():
 
     # run the payload's command
     # - do non-blocking reads of the process's output, ensure all output is printed
-    #   - see https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options
+    #   - more info
+    #     - https://bugzilla.mozilla.org/show_bug.cgi?id=1611936
+    #     - https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options
     print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None
     proc = subprocess.Popen(extra_args,

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -225,7 +225,8 @@ def main():
     print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None
     proc = subprocess.Popen(extra_args,
-                            bufsize=0,
+                            # use standard os buffer size
+                            bufsize=-1,
                             env=env,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -20,6 +20,7 @@ from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
 
+
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
     TBPL_RETRY_EXIT_STATUS this will cause the job to be retried.
@@ -35,6 +36,7 @@ def fatal(message, exception=None, retry=True):
         print("{}: {}".format(exception.__class__.__name__, exception))
     sys.exit(exit_code)
 
+
 def show_df():
     try:
         print('\ndf -h\n%s\n\n' % subprocess.check_output(
@@ -42,6 +44,7 @@ def show_df():
             stderr=subprocess.STDOUT).decode())
     except subprocess.CalledProcessError as e:
         print('{} attempting df'.format(e))
+
 
 def get_device_type(device):
     device_type = device.shell_output("getprop ro.product.model", timeout=ADB_COMMAND_TIMEOUT)
@@ -54,6 +57,7 @@ def get_device_type(device):
     else:
         fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     return device_type
+
 
 def enable_charging(device, device_type):
     p2_path = "/sys/class/power_supply/battery/input_suspend"
@@ -95,6 +99,7 @@ def enable_charging(device, device_type):
         )
         print("{}: {}".format(e.__class__.__name__, e))
 
+
 def _monitor_readline(process, q):
     while True:
         bail = True
@@ -104,6 +109,7 @@ def _monitor_readline(process, q):
         q.put(out)
         if q.empty() and bail:
             break
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -211,7 +211,7 @@ def main():
     print('environment = {}'.format(json.dumps(env, indent=4)))
 
     # run the payload's command
-    # - do non-blocking reads of process' output, ensure all output is printed
+    # - do non-blocking reads of the process's output, ensure all output is printed
     #   - see https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options
     print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -271,10 +271,6 @@ def main():
 
     show_df()
 
-    if rc is None:
-        print("script.py: setting exit code to 1 due to timeout")
-        rc = 1
-
     print('script.py: exiting with exitcode {}.'.format(rc))
     return rc
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -9,13 +9,9 @@ import json
 import logging
 import os
 import queue
-import shlex
-import signal
 import subprocess
 import sys
 import threading
-import time
-from contextlib import contextmanager
 from datetime import datetime
 from glob import glob
 

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -216,8 +216,9 @@ def main():
 
     print('environment = {}'.format(json.dumps(env, indent=4)))
 
-    # run the payload's command
-    # - do non-blocking reads of the process's output, ensure all output is printed
+    # run the payload's command and ensure that:
+    # - all output is printed
+    # - no deadlock occurs between proc.poll() and sys.stdout.readline()
     #   - more info
     #     - https://bugzilla.mozilla.org/show_bug.cgi?id=1611936
     #     - https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options

--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -8,15 +8,21 @@ import argparse
 import json
 import logging
 import os
+import queue
+import shlex
+import signal
 import subprocess
 import sys
+import threading
+import time
+from contextlib import contextmanager
+from datetime import datetime
 from glob import glob
 
 from mozdevice import ADBDevice, ADBError, ADBHost, ADBTimeoutError
 
 MAX_NETWORK_ATTEMPTS = 3
 ADB_COMMAND_TIMEOUT = 10
-
 
 def fatal(message, exception=None, retry=True):
     """Emit an error message and exit the process with status
@@ -52,7 +58,6 @@ def get_device_type(device):
     else:
         fatal("Unknown device ('%s')! Contact Android Relops immediately." % device_type, retry=False)
     return device_type
-
 
 def enable_charging(device, device_type):
     p2_path = "/sys/class/power_supply/battery/input_suspend"
@@ -94,10 +99,21 @@ def enable_charging(device, device_type):
         )
         print("{}: {}".format(e.__class__.__name__, e))
 
+def _monitor_readline(process, q):
+    while True:
+        bail = True
+        if process.poll() is None:
+            bail = False
+        out = process.stdout.readline().decode()
+        q.put(out)
+        if q.empty() and bail:
+            break
+
 def main():
     parser = argparse.ArgumentParser(
         usage='%(prog)s [options] <test command> (<test command option> ...)',
-        description="Wrapper script for tests run on physical Android devices at Bitbar. Runs the provided command wrapped with required setup and teardown.")
+        description="Wrapper script for tests run on physical Android devices at Bitbar. Runs the provided command "
+                    "wrapped with required setup and teardown.")
     _args, extra_args = parser.parse_known_args()
     logging.basicConfig(format='%(asctime)-15s %(levelname)s %(message)s',
                         level=logging.INFO,
@@ -199,26 +215,44 @@ def main():
     print('environment = {}'.format(json.dumps(env, indent=4)))
 
     # run the payload's command
+    # - do non-blocking reads of process' output, ensure all output is printed
+    #   - see https://stackoverflow.com/questions/58471094/python-subprocess-readline-hangs-cant-use-normal-options
     print("script.py: running command '%s'" % ' '.join(extra_args))
     rc = None
-    bytes_read = 0
-    bytes_written = 0
     proc = subprocess.Popen(extra_args,
                             bufsize=0,
                             env=env,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
+                            stderr=subprocess.STDOUT,
+                            close_fds=True)
+    # Create the queue instance
+    q = queue.Queue()
+    # Kick off the monitoring thread
+    thread = threading.Thread(target=_monitor_readline, args=(proc, q))
+    thread.daemon = True
+    thread.start()
+    start = datetime.now()
     while True:
-        line = proc.stdout.readline()
-        decoded_line = line.decode()
-        line_len = len(decoded_line)
-        bytes_read += line_len
+        bail = True
         rc = proc.poll()
-        if line:
-            bytes_written += sys.stdout.write(decoded_line)
-        if line_len == 0 and bytes_written == bytes_read and rc is not None:
+        if rc is None:
+            bail = False
+            # Re-set the thread timer
+            start = datetime.now()
+        out = ""
+        while not q.empty():
+            out += q.get()
+        if out:
+            print(out.rstrip())
+
+        # In the case where the thread is still alive and reading, and
+        # the process has exited and finished, give it up to X seconds
+        # to finish reading
+        if bail and thread.is_alive() and (datetime.now() - start).total_seconds() < 5:
+            bail = False
+        if bail:
             break
-    print("script.py: command finished (bytes read: %s, bytes written: %s)" % (bytes_read, bytes_written))
+    print("script.py: command finished")
 
     # enable charging on device if it is disabled
     #   see https://bugzilla.mozilla.org/show_bug.cgi?id=1565324
@@ -240,6 +274,10 @@ def main():
         print('{} attempting netstat'.format(e))
 
     show_df()
+
+    if rc is None:
+        print("script.py: setting exit code to 1 due to timeout")
+        rc = 1
 
     print('script.py: exiting with exitcode {}.'.format(rc))
     return rc


### PR DESCRIPTION
solves script.py hanging. refines fix from #41 (https://github.com/bclary/mozilla-bitbar-docker/pull/41/commits/16449204b5605fabde8ddaf27d7442758535a895).

will build from branch and run tests before landing.

https://bugzilla.mozilla.org/show_bug.cgi?id=1611936

test plan:
- test with gbrown's commit that causes timeouts
  - `./mach try fuzzy --full --query "android-hw 'debug-geckoview-mochitest-webgl1 \!fis" --no-push`
  - https://hg.mozilla.org/try/rev/3ece44e8b5145a6f76d1fab54f78ae1f854e0d6f
- test with normal suite of verification tests
  - `./mach try fuzzy --no-artifact  --full --query "'android-hw \!power \!nightly \!pgo '-1-" --query "'android-hw-p2 'pgo-geckoview-jsreftest-e10s" --no-push`