### PR TITLE
script.py: reduce cpu

### DIFF
--- a/taskcluster/script.py
+++ b/taskcluster/script.py
@@ -12,6 +12,7 @@ import queue
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime
 from glob import glob
 
@@ -239,6 +240,7 @@ def main():
     thread.start()
     start = datetime.now()
     while True:
+        time.sleep(0.1)
         bail = True
         rc = proc.poll()
         if rc is None:


### PR DESCRIPTION
### overview

Bitbar noticed a rise in CPU usage after #42 landed and was made default. Try to fix that.

I think it's due to the main queue consumer loop being overly aggressive.

### testing

old: 465271e5fa189595041e3af13ca5c964b6f67ac5
new: 66a39cd92a13aaa879c42db1d8fc261895743825
rev 1: add a time.sleep(0.1) at start of main loop

test scripts available at https://github.com/aerickson/mozilla-bitbar-docker/tree/local_testing

#### rand text (dumps 10MB of rand text in one line)

old:

real	0m13.203s
user	0m5.137s
sys	0m4.473s

new:

real	0m5.330s
user	0m1.230s
sys	0m1.110s

#### sleep_45

new

real	0m49.025s
user	0m21.814s
sys	0m23.930s

old

real	0m48.976s
user	0m0.246s
sys	0m0.305s

rev 1

real	0m53.894s
user	0m5.049s
sys	0m0.784s

#### sleep 60

new

real	1m4.460s
user	0m29.108s
sys	0m31.959s

rev 1

real	1m9.137s
user	0m5.181s
sys	0m0.708s

old

real	1m4.017s
user	0m0.247s
sys	0m0.255s

#### sleep 120

rev 1: 

real	2m9.283s
user	0m5.308s
sys	0m0.816s

old:

real	2m4.079s
user	0m0.271s
sys	0m0.322s

#### sleep 240

rev 1:

real	4m4.988s
user	0m0.997s
sys	0m0.629s

old:

real	4m4.296s
user	0m0.331s
sys	0m0.485s
