### PR TITLE
change g-w timeout to 90 minutes

### DIFF
--- a/taskcluster/worker-runner-config.yml.template
+++ b/taskcluster/worker-runner-config.yml.template
@@ -14,7 +14,7 @@ worker:
 workerConfig:
     certificate:                ""
     ed25519SigningKeyLocation:   "${ED25519_PRIVKEY}"
-    idleTimeoutSecs:            90
+    idleTimeoutSecs:            5400
     livelogExecutable:          "/usr/local/bin/livelog"
     numberOfTasksToRun:         1
     provisionerId:              "proj-autophone"


### PR DESCRIPTION
If devicepool starts more bitbar runs than tc jobs, we might as well sit around for a bit and wait for new jobs to come in and handle them faster than we would normally (since we're already booted up and waiting for a job).